### PR TITLE
fix: FT_New_Memory_Face "file_base" arg mem is freed by GC

### DIFF
--- a/spec/freetype2_spec.js
+++ b/spec/freetype2_spec.js
@@ -13,13 +13,6 @@ describe('freetype2', function() {
       face = face.face;
       expect(tv4.validate(face, schema.FontFace)).toBe(true, !!tv4.error ? tv4.error.toString() : undefined);
     });
-
-    it ('aface parameter is optional if face_index is less than zero', function() {
-      var err = ft.New_Memory_Face(buffer, 0);
-      expect(err).not.toBe(0);
-      err = ft.New_Memory_Face(buffer, -1);
-      expect(err).toBe(0);
-    });
   });
 
   describe('#Get_Char_Index', function() {

--- a/src/FontFace.cc
+++ b/src/FontFace.cc
@@ -54,10 +54,14 @@ NAN_METHOD(FontFace::New) {
   info.GetReturnValue().Set(info.This());
 }
 
-FontFace::FontFace() {}
+FontFace::FontFace() {
+  this->ftFace = 0;
+  this->data = NULL;
+}
 
 FontFace::~FontFace() {
   FT_Done_Face(this->ftFace);
+  free(this->data);
 }
 
 NAN_GETTER(FontFace::acc_num_faces) {

--- a/src/FontFace.h
+++ b/src/FontFace.h
@@ -10,6 +10,7 @@ class FontFace : public node::ObjectWrap {
   public:
     static v8::Local<v8::Function> GetConstructor();
     FT_Face ftFace;
+    FT_Byte* data;
 
   private:
     explicit FontFace();


### PR DESCRIPTION
Memory corruption in New_Memory_Face, Load_Glyph, Load_Char.
Docs say buffer fed to FT_New_Memory_Face should be preserved.
http://www.freetype.org/freetype2/docs/reference/ft2-base_interface.html#FT_New_Memory_Face
But it is freed by garbage collector. Also i ensure third argument `face` for New_Memory_Face to store `data` pointer in. Probably some test/examples should be fixed too. But `ntk` seems to always use `face` argument.

I can post Valgrind logs.
