### PR TITLE
fix: thread safety

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "install": "node-gyp-build",
     "vendor": "ts-node ./vendor/download-freetype.ts",
-    "prebuild": "prebuildify --napi --strip --tag-libc",
+    "prebuild2": "prebuildify --napi --strip --tag-libc",
     "clean": "node-gyp clean",
     "build": "node-gyp configure && node-gyp build",
     "test": "jest",
@@ -37,11 +37,11 @@
   },
   "binary": {
     "napi_versions": [
-      3
+      6
     ]
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=12.17"
   },
   "dependencies": {
     "bindings": "^1.5.0",

--- a/src/FontFace.cc
+++ b/src/FontFace.cc
@@ -1,14 +1,12 @@
 #include "FontFace.h"
 #include <iostream>
 
-Napi::FunctionReference FontFace::constructor;
-
 /**
  * Unimplemented:
  * FT_Face_Properties
  */
 
-void
+Napi::FunctionReference
 FontFace::Initialize(Napi::Env& env) {
   Napi::HandleScope scope(env);
 
@@ -39,8 +37,7 @@ FontFace::Initialize(Napi::Env& env) {
 
   });
 
-  constructor = Napi::Persistent(ctor);
-  constructor.SuppressDestruct();
+  return Napi::Persistent(ctor);
 }
 
 FontFace::FontFace(const Napi::CallbackInfo& info)

--- a/src/FontFace.h
+++ b/src/FontFace.h
@@ -8,10 +8,8 @@ class FontFace : public Napi::ObjectWrap<FontFace> {
     FT_Face ftFace;
     Napi::Reference<Napi::Buffer<FT_Byte>> bufferRef;
 
-    static Napi::FunctionReference constructor;
-
     FontFace(const Napi::CallbackInfo& info);
-    static void Initialize(Napi::Env& env);
+    static Napi::FunctionReference Initialize(Napi::Env& env);
 
     ~FontFace();
 

--- a/src/util.h
+++ b/src/util.h
@@ -1,4 +1,7 @@
-#define NAPI_VERSION 3
+#ifndef NODE_FREETYPE2_UTIL_H
+#define NODE_FREETYPE2_UTIL_H
+
+#define NAPI_VERSION 6
 #include <napi.h>
 
 #include <ft2build.h>
@@ -11,3 +14,10 @@ bool validateProp(const Napi::Env& env, bool isCorrect, const char* propName);
 bool validatePropsLength(const Napi::Env& env, const Napi::CallbackInfo &info, unsigned int minLength);
 
 bool checkProperty(const Napi::Object& obj, const char* name);
+
+struct InstanceData {
+  FT_Library library;
+  Napi::FunctionReference fontFace;
+};
+
+#endif


### PR DESCRIPTION
There are some thread safety issues left behind when I ported this to node-api a while back, making it not suitable for use in worker-threads
Mostly a few global static properties, and not cleaning up when a thread is destroyed.

The call to `constructor.SuppressDestruct()` is not safe: https://github.com/nodejs/node-addon-api/blob/main/doc/reference.md#suppressdestruct
The docs show to use `env.SetInstanceData()` to preserve values instead: https://github.com/nodejs/node-addon-api/blob/main/doc/object_wrap.md#example

This does require bumping the napi_version to 6, which is supporter in 12.17+