### PR TITLE
chore: remove unused bindings dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "node": ">=12"
   },
   "dependencies": {
-    "bindings": "^1.5.0",
     "node-addon-api": "^4.3.0",
     "node-gyp-build": "^4.4.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,6 @@ specifiers:
   '@types/fs-extra': ^9.0.13
   '@types/node': ^17.0.24
   ajv: ^8.11.0
-  bindings: ^1.5.0
   decompress: ^4.2.1
   decompress-tarxz: ^3.0.0
   download: ^8.0.0
@@ -25,7 +24,6 @@ specifiers:
   typescript: ^4.6.3
 
 dependencies:
-  bindings: 1.5.0
   node-addon-api: 4.3.0
   node-gyp-build: 4.4.0
 
@@ -961,12 +959,6 @@ packages:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
     dev: true
 
-  /bindings/1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
-    dependencies:
-      file-uri-to-path: 1.0.0
-    dev: false
-
   /bl/1.2.3:
     resolution: {integrity: sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==}
     dependencies:
@@ -1623,10 +1615,6 @@ packages:
     resolution: {integrity: sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==}
     engines: {node: '>=4'}
     dev: true
-
-  /file-uri-to-path/1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
-    dev: false
 
   /filename-reserved-regex/2.0.0:
     resolution: {integrity: sha1-q/c9+rc10EVECr/qLZHzieu/oik=}


### PR DESCRIPTION
`bindings` isn't used anymore. it was replaced with `node-gyp-build` when you switched to `prebuildify`